### PR TITLE
Return all ids as strings

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -3,8 +3,7 @@ var router = express.Router();
 var db = require("../db.js");
 
 router.route("/").get(function (req, res) {
-  let user = req.body;
-  db.users.getById(user).then((user) => {
+  db.users.getById(req.session.userId, req.session.userId).then((user) => {
     if (!user) {
       res.statusCode = 404;
       res.end();


### PR DESCRIPTION
Fixing https://github.com/ParaLibrary/paralibrary-backend/pull/40 made it clear that another bug is happening - the backend is still returning all id's (book, user, loan, etc) as integers instead of strings. 

This causes the bug where a book shows the "Request Loan" instead of "Cancel" because it's comparing `1 === "1"`, which is false